### PR TITLE
Update core.sh

### DIFF
--- a/src/core.sh
+++ b/src/core.sh
@@ -54,7 +54,7 @@ function install_via_nix {
     PATH=/nix/var/nix/profiles/default/bin/:$PATH
     nix-env --install --file "$INPUT_NIX_FILE"
   else 
-    echo "File at `nix_file` does not exist"
+    echo "File at nix_file does not exist"
     exit 1
   fi
 }


### PR DESCRIPTION
https://github.com/rikhuijzer/cache-install/blob/138361d26eeecf28d796a4e778761fb0f9b71625/src/core.sh#L57

Using `` ` ` `` causes shell evaluation of `nix_file` and leads to a weird error...

This error hides a more problematic one: where does the shell variable `INPUT_NIX_FILE` come from?