### PR TITLE
Fix run path for script `core.sh`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Prepare for restoring cache
       shell: bash
-      run: ./src/core.sh "prepare-restore"
+      run: $GITHUB_ACTION_PATH/src/core.sh "prepare-restore"
 
     - name: Pass USER to GitHub Action
       id: user
@@ -55,15 +55,15 @@ runs:
     - name: Install with cache
       if: steps.cache.outputs.cache-hit == 'true'
       shell: bash
-      run: ./src/core.sh "install-from-cache"
+      run: $GITHUB_ACTION_PATH/src/core.sh "install-from-cache"
 
     - name: Install without cache
       # Use `!= 'true'` because `cache-hit` is not set if no cache was restored.
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-          ./src/core.sh "install-with-nix"
-          ./src/core.sh "prepare-save"
+          $GITHUB_ACTION_PATH/src/core.sh "install-with-nix"
+          $GITHUB_ACTION_PATH/src/core.sh "prepare-save"
       env:
         INPUT_NIX_FILE: ${{ inputs.nix_file }}
         INPUT_NIX_VERSION: ${{ inputs.nix_version }}


### PR DESCRIPTION
Running the new v1.1.0 gives this error when used
```
Run rikhuijzer/cache-install@f0651c79209b5e7befbce5621f9102ee304024df
Run src/core.sh "prepare-restore"
/home/runner/work/_temp/49c87ab0-5bab-4b44-af36-ece026979fc1.sh: line 1: ./src/core.sh: No such file or directory
Error: Process completed with exit code 127.

```
I've added an explicit path by using the Github variable `$GITHUB_ACTION_PATH` prefixed to each invocation of `src/core.sh` in `action.yaml`. All CI tests should pass (tested locally with `act`) and using this specific git commit SHA I can now use it with our repo again.