### PR TITLE
Cache the Nix database too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Save cache
       uses: ./
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Restore cache
       id: cache
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Save cache
       uses: ./
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Restore cache
       uses: ./
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Save cache
       uses: ./
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Restore cache
       uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,9 @@ jobs:
         fi
 
     - name: Test whether simple.nix is installed
-      run: hello
+      run: |
+        nix-store --gc # Remove invalid store paths
+        hello
 
 
 
@@ -84,7 +86,9 @@ jobs:
         nix_file: 'test/latex.nix'
 
     - name: Test whether latex.nix is installed
-      run: which pdfcrop
+      run: |
+        nix-store --gc # Remove invalid store paths
+        which pdfcrop
 
 
 
@@ -119,4 +123,6 @@ jobs:
         nix_file: 'test/simple.nix'
 
     - name: Test whether simple.nix is installed
-      run: hello
+      run: |
+        nix-store --gc # Remove invalid store paths
+        hello

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Cache install Nix packages
       uses: rikhuijzer/cache-install@v1

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: 'default.nix'
   nix_install_url:
     description: 'Install URL for the Nix package manager; obtain newest via https://nixos.org/nix/install.'
-    default: 'https://releases.nixos.org/nix/nix-2.13.0/install'
+    default: 'https://releases.nixos.org/nix/nix-2.19.1/install'
 
 outputs:
   cache-hit:

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,8 @@ runs:
       with:
         path: |
           /nix/store/
+          /nix/var/nix/db/db.sqlite
+          /nix/var/nix/db/schema
           /nix/var/nix/profiles/per-user/${{ env.USER }}/profile/bin/
           /nix/var/nix/profiles/default/bin/
           /nix/var/nix/profiles/per-user/root/channels/
@@ -75,6 +77,8 @@ runs:
       with:
         path: |
           /nix/store/
+          /nix/var/nix/db/db.sqlite
+          /nix/var/nix/db/schema
           /nix/var/nix/profiles/per-user/${{ env.USER }}/profile/bin/
           /nix/var/nix/profiles/default/bin/
           /nix/var/nix/profiles/per-user/root/channels/

--- a/src/core.sh
+++ b/src/core.sh
@@ -37,6 +37,10 @@ function install_nix {
   sh <(curl --silent --retry 5 --retry-connrefused -L "${INPUT_NIX_INSTALL_URL}") \
     "${installer_options[@]}"
 
+  # Create the user profile
+  sudo mkdir "/nix/var/nix/profiles/per-user/$USER"
+  sudo chown $USER "/nix/var/nix/profiles/per-user/$USER"
+
   if [[ $OSTYPE =~ darwin ]]; then
     # Disable spotlight indexing of /nix to speed up performance
     sudo mdutil -i off /nix

--- a/src/core.sh
+++ b/src/core.sh
@@ -105,6 +105,13 @@ function undo_prepare {
   sudo rm -rf /nix
 }
 
+function clean_nix_store {
+  PATH=/nix/var/nix/profiles/default/bin/:$PATH
+
+  nix-store --gc
+  nix-store --optimise
+}
+
 TASK="$1"
 if [ "$TASK" == "prepare-restore" ]; then
   prepare
@@ -121,6 +128,7 @@ elif [ "$TASK" == "install-from-cache" ]; then
   set_nix_profile_symlink
 elif [ "$TASK" == "prepare-save" ]; then
   prepare
+  clean_nix_store
 else
   echo "Unknown argument given to core.sh: $TASK"
   exit 1


### PR DESCRIPTION
Nix records all store paths in its database. If Nix evaluates an expression which refers to a store path not in the Nix database, it will rebuilt the corresponding derivation. Hence, such paths aren't really cached. The garbage collector also checks the validity of store paths (and requires the database to find dependencies) and deletes all invalid paths.
I discovered this bug by using this action to store the dependencies of a Nix expression which I wanted to built in CI. In essence, I use `nixpkgs.mkShell` to cache the dependencies (which require a long time to built). However, they where still built every time the CI was run.

Note that this PR includes three more commits (I can open separate PRs for these if you want):
- Bump dependency versions
- Reduce the cache size by running the garbage collector